### PR TITLE
Tr translations for student-faq and quick python

### DIFF
--- a/templates/en/resources/quick-python.md
+++ b/templates/en/resources/quick-python.md
@@ -16,7 +16,7 @@ To print out something to the console:
 
     print("This is a message")
 
-Note that `print( ... )` must have a `string` within the parentheses (remember, `string` can be thought of as a data type that stores text). To print out a message to the console that involves a variable that is an integer or double, you will need to *cast* the variable to a string using the function `str(...)`:
+Note that `print( ... )` must have a `string` within the parentheses (remember, `string` can be thought of as a data type that stores text). To print out a message to the console that involves a variable that is an integer or float, you will need to *cast* the variable to a string using the function `str(...)`:
 
 ```
 message = "This is a string"

--- a/templates/en/resources/student-faq.md
+++ b/templates/en/resources/student-faq.md
@@ -47,4 +47,4 @@ Yes! All lectures will be recorded and posted to the "Lectures" category on the 
  
 
 <br/>
-*Have a question which wasn't covered here? Please post on [Ed](https://us.edstem.org/courses/490).*
+*Have a question which wasn't covered here? Please post on [Ed](https://us.edstem.org/courses/968).*

--- a/templates/tr/resources/quick-python.md
+++ b/templates/tr/resources/quick-python.md
@@ -1,0 +1,81 @@
+template: templates/en/resources/faqTemplate.ptl
+title: Hızlı Python Referansı
+
+[TOC]
+
+## PyCharm'da Python programları nasıl çalıştırılır
+PyCharm'da bir program çalıştırmak için sayfanın altındaki "Terminal" opsiyonuna tıklayın. Herhangi bir programı çalıştırmak için aşağıdaki komutu Terminal'e girip "Enter"'a basmanız yeterli:
+
+* **Mac Users**: `python3 programinizin_adi.py`
+* **PC Users**: `programinizin_adi.py`
+
+Yukarıdaki komutu çalıştırdıktan sonra terminal (**konsol** olarak da bilinir) programınızın çıktısını yazdırır ve programınızı nasıl yazdığınıza göre kullanıcıdan yazılı veri girişi alabilir.
+
+## Konsol Çıktısı
+Konsola bir şeyler yazdırmak için:
+
+    print("Bu bir mesajdır.")
+
+`print( ... )` fonksiyonu parantezlerin içine bir `string` almalıdır (unutmayın, `string` metin tutan bir veri türü olarak düşünülebilir). Konsola integer (tamsayı) ya da float (rasyonel sayılar) türünde bir değişken içeren bir mesaj yazdırmak istediğinizde bu değişkeni `str(...)` fonksiyonunu kullanarak string'e *çevirmeniz* gerekecek:
+
+```
+message = "Bu bir string"
+print(message)                        # message zaten string türünde bir değişken
+x = 5                                 # int
+print("Değişken x'in değeri: " + str(x))
+pi = 3.14                             # float
+print("Pi'nin yaklaşık değeri: " + str(pi))
+```
+
+Yukarıdaki kod çalıştırıldığında aşağıdaki çıktıyı verir:
+
+```
+Bu bir string
+Değişken x'in değeri: 5
+Pi'nin yaklaşık değeri: 3.14
+```
+
+## Konsol Girdisi
+
+Kullanıcıdan konsol aracılığıyla girdi alıp değerini bir değişkende tutmak için ```input(..)``` fonksiyonu kullanılır. Kullanıcı girdisini başka türde (integer, float, vb.) veri yapılarında tutmak için girdiyi istediğiniz türe **çevirmeniz** gerekecektir. 
+
+```
+what_you_said = input("How are you doing? ")            # Kullanıcıya nasıl olduğu soruluyor
+print("You said: " + what_you_said)                     # Kullanıcının cevabı konsola geri yazdırılıyor
+
+radius = int(input("Enter an integer: "))               # Kullanıcıdan çemberin yarı çapı isteniyor ve değeri int olarak radius değişkeninde tutuluyor
+diameter = 2 * radius                                   # Çap
+print("diameter = " + str(diameter))
+pi = float(input("Enter your best guess at pi: "))      # Kullanıcıdan pi için en iyi tahminini girmesi isteniyor
+circumference = pi*diameter     
+print("circumference = " + str(circumference))          # Çemberin çevresi konsola yazdırılıyor
+```
+
+Yukarıdaki kod çalıştırıldığında aşağıdaki çıktıyı verir (Kullanıcı girdisi mavi ile belirtilmiştir):
+
+<center>
+<img
+  src="{{pathToRoot}}img/resources/quick-python/input_demo.png"
+  class="img-fluid mx-auto d-block"
+  style="width: 55%"
+  alt="Konsol girişi için örnek sonuç. Kullanıcı girdileri "Fine, thank you", daha sonra "4", sonra da "3.1415926535323846" ve program yarı çapı 4 olan bir çemberin çevresini sizin girdiğiniz pi (\pi) değeri ile hesaplar.
+/>
+</center>
+
+## Rastgele Sayılar
+
+Rastgele sayılar üretmek için programınızın başına, fonksiyonların dışına `import random` yazın.
+
+```
+import random
+
+def main():
+    ...
+```
+
+Daha sonra aşağıdaki gibi rastgele sayılar elde edebilirsiniz. Rastgele sayıların üretilmesini istediğimiz alt ve üst limiti `lower = 0` ve `upper = 10` olarak tanımladığımızı varsayın.:
+
+```
+x = random.randint(lower, upper)  # [lower, upper] aralığında (alt ve üst limit dahil) rastgele bir tamsayı
+y = random.random()               # 0 ve 1 arasında rastgele rasyonel sayı
+y = random.uniform(lower, upper)  # [lower, upper] aralığında rastgele rasyonel sayı 

--- a/templates/tr/resources/quick-python.md
+++ b/templates/tr/resources/quick-python.md
@@ -6,8 +6,8 @@ title: Hızlı Python Referansı
 ## PyCharm'da Python programları nasıl çalıştırılır
 PyCharm'da bir program çalıştırmak için sayfanın altındaki "Terminal" opsiyonuna tıklayın. Herhangi bir programı çalıştırmak için aşağıdaki komutu Terminal'e girip "Enter"'a basmanız yeterli:
 
-* **Mac Users**: `python3 programinizin_adi.py`
-* **PC Users**: `programinizin_adi.py`
+* **Mac Kullanıcıları**: `python3 programinizin_adi.py`
+* **PC Kullanıcıları**: `programinizin_adi.py`
 
 Yukarıdaki komutu çalıştırdıktan sonra terminal (**konsol** olarak da bilinir) programınızın çıktısını yazdırır ve programınızı nasıl yazdığınıza göre kullanıcıdan yazılı veri girişi alabilir.
 
@@ -41,12 +41,12 @@ Kullanıcıdan konsol aracılığıyla girdi alıp değerini bir değişkende tu
 
 ```
 what_you_said = input("How are you doing? ")            # Kullanıcıya nasıl olduğu soruluyor
-print("You said: " + what_you_said)                     # Kullanıcının cevabı konsola geri yazdırılıyor
+print("You said: " + what_you_said)                     # Kullanıcının cevabı konsola yazdırılıyor
 
-radius = int(input("Enter an integer: "))               # Kullanıcıdan çemberin yarı çapı isteniyor ve değeri int olarak radius değişkeninde tutuluyor
+radius = int(input("Enter an integer: "))               # Kullanıcıdan alınan yarı çap değeri int olarak radius değişkeninde tutuluyor
 diameter = 2 * radius                                   # Çap
 print("diameter = " + str(diameter))
-pi = float(input("Enter your best guess at pi: "))      # Kullanıcıdan pi için en iyi tahminini girmesi isteniyor
+pi = float(input("Enter your best guess at pi: "))      # Kullanıcıdan pi tahmini isteniyor
 circumference = pi*diameter     
 print("circumference = " + str(circumference))          # Çemberin çevresi konsola yazdırılıyor
 ```
@@ -79,3 +79,4 @@ Daha sonra aşağıdaki gibi rastgele sayılar elde edebilirsiniz. Rastgele say�
 x = random.randint(lower, upper)  # [lower, upper] aralığında (alt ve üst limit dahil) rastgele bir tamsayı
 y = random.random()               # 0 ve 1 arasında rastgele rasyonel sayı
 y = random.uniform(lower, upper)  # [lower, upper] aralığında rastgele rasyonel sayı 
+```

--- a/templates/tr/resources/student-faq.md
+++ b/templates/tr/resources/student-faq.md
@@ -6,9 +6,6 @@ title: CS Bridge SSS
 <!-- Table of Contents -->
 [TOC]
 
-## General
-
-# Öğrenciler için Sıkça Sorulan Sorular
 
 ### Bu program notlandırılıyor mu?
 

--- a/templates/tr/resources/student-faq.md
+++ b/templates/tr/resources/student-faq.md
@@ -1,29 +1,50 @@
 template: templates/tr/resources/faqTemplate.ptl
-title: CS Bridge FAQs
+title: CS Bridge SSS
 
-*Do you have a question about Code in Place? It might be answered here.*
+*CS Bridge hakkında bir sorunuz mu var? Bu sayfada cevaplanmış olabilir.*
 
 <!-- Table of Contents -->
 [TOC]
 
 ## General
 
-# Student FAQ test
+# Öğrenciler için Sıkça Sorulan Sorular
 
-### Is this course graded?
+### Bu program notlandırılıyor mu?
 
-No, this is purely for the joy of learning!
+Hayır, bu programı sadece öğrenmenin keyfi için düzenliyoruz!
 
-### Will I receive a certificate of completion?
-                            
-We don’t promise a certificate of completion. This class is purely for the joy of learning! We are talking to folks to see what is possible and it seems very reasonable that we could help you share that you participated in this experience :-)
+### Bitirme sertifikası alacak mıyım?
 
-### How can I make the most of this course? 
+Evet, bütün programa katılım sağlarsanız bir bitirme sertifikası alacaksınız.
 
-Have fun with it. Do the readings. Come to section. Download PyCharm and do the assignments. Learn from your community on Ed.
-### I have a suggestion for improving the course. How can I tell you?
+### Bu kurstan en iyi şekilde nasıl yararlanabilirim?
 
-Wonderful. Please fill out <a href='https://docs.google.com/forms/d/e/1FAIpQLSdINcYsz1JN8eekMJntExxNyz7m5fa6JKztT_pkeYqfUMIRwg/viewform'>this form</a>. We want to improve this course and love suggestions! We might not be able to make all suggestions happen this term, but you could still be helping future students.
+Olabildiğince eğlenmeye çalışın. Program aktivitelerinin hepsine katılın: dersleri dinleyin, projeniz için çalışın, ihtiyaç duyduğunuzda ofis saatlerine katılın ya da Grup Liderinizden yardım isteyin, CS Bridge topluluğu ile Ed üzerinden etkileşime geçin ve aynı anda hem kodlamayı öğrenin hem de yeni arkadaşlar edinin!
+
+### Program hakkında genel bir sorum var, nerede sorabilirim?
+
+CS Bridge [Ed sayfası](https://us.edstem.org/courses/968/discussion/) genel sorularınızı sormak için en doğru yer. Ed'deki kategorileri kontrol edin ve sorunuzu en çok kapsayan kategoriyi seçin. Gün boyunca Ed'i kontrol edeceğiz ve sorularınızı olabildiğince hızlı cevaplamaya çalışacağız.
+
+### Hastayım (ya da başka bir işim çıktı) ve Ders/Çay Saati/Grup buluşmamıza katılamayacağım, ne yapmalıyım?
+
+Bu programı, düzenlenen bütün aktivitelere katılacağınız beklentisi ile tasarladık ancak beklenmedik durumların oluşabileceğinin farkındayız (hastalanabilir ya da ani bir kişisel sorunla karşılaşabilirsiniz), böyle bir durumda, özellikle bir aktiviteye katılamayacaksanız, en kısa zamanda Grup Liderinize Ed üzerinden özel mesaj gönderin. Grup Liderleriniz programdad geri kalmamanız için sizi yönlendirecektir. 
+
+### Ödevimi erken bitirdim, fazla zamanımla ne yapabilirim?
+
+Öğrendiğiniz konseptlerle yapabileceğiniz eğlenceli şeyleri düşünün; fikirlerinizi ve yaptıklarınızı diğer öğrencilerle Ed üzerinden paylaşın.
+
+### Daha ödevimi bitirmedim ama teslim zamanı geldi, ne yapabilirim? 
+
+Yazabildiğiniz kadar kodu teslim edin.
+
+### Kayboldum. Nerede olmalıym? 
+
+Grubunuzun Ed sayfasında paylaşılan zaman çizelgesini kontrol edin. Aktivitelerin zamanlarını ve Zoom linklerini bu sayfada bulabilirsiniz.
+
+### Dersleri tekrar izleyebilir miyim?
+
+Evet! Bütün dersler kaydedilip CS Bridge Ed sayfasının "Dersler" (Lectures) bölümünde sizinle paylaşılacak.
 
 <br/>
-*Have a question which wasn't covered here? Please post on [Ed](https://us.edstem.org/courses/490).*
+* Bu sayfada cevaplanmamış sorularınızı [Ed](https://us.edstem.org/courses/968) üzerinden sorabilirsiniz.*


### PR DESCRIPTION
- Translated Student FAQ and Quick Python
- Corrected the Ed link in both En and Tr versions of these pages (it was pointing to the Code In Place Ed page) (490 -> 968)
- Changed wording `double` to `float` in quick python
